### PR TITLE
fix-for-issue-1108

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
@@ -44,7 +45,7 @@ public class MessageWindowChatMemory implements ChatMemory {
     private final ChatMemoryStore store;
 
     private MessageWindowChatMemory(Builder builder) {
-        this.id = ensureNotNull(builder.id, "id");
+        this.id = builder.id == null ? UUID.randomUUID() : builder.id;
         this.maxMessages = ensureGreaterThanZero(builder.maxMessages, "maxMessages");
         this.store = ensureNotNull(builder.store, "store");
     }
@@ -120,13 +121,13 @@ public class MessageWindowChatMemory implements ChatMemory {
 
     public static class Builder {
 
-        private Object id = "default";
+        private Object id = null;
         private Integer maxMessages;
         private ChatMemoryStore store = new InMemoryChatMemoryStore();
 
         /**
          * @param id The ID of the {@link ChatMemory}.
-         *           If not provided, a "default" will be used.
+         *           If not provided, a random UUID will be used.
          * @return builder
          */
         public Builder id(Object id) {


### PR DESCRIPTION
## Context
Solves #1108.

## Change
- The default value of `id` in `MessageWindowChatMemory.Builder` is null.
- The constructor of `MessageWindowChatMemory` checks for null `id` value. If it is `null`, then it will generate a random UUID.
- Updated the documentation for `MessageWindowChatMemory.Builder.id()`.

## Checklist
Before submitting this PR, please check the following points:
- [ ] I have added unit and integration tests for my change
- [x] All unit and integration tests in the module I have added/changed are green
- [x] All unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules are green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added my new module in the [BOM](https://github.com/langchain4j/langchain4j/blob/main/langchain4j-bom/pom.xml) (only when a new module is added)
