### PR TITLE
fix-for-301-inmemory

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,41 +1,50 @@
-name: release
+name: Nightly Build
 
 on:
+  schedule:
+    - cron: '0 0 * * *'  # daily at midnight UTC
   workflow_dispatch:
 
 jobs:
-
-  release:
+  java_build:
+    strategy:
+      matrix:
+        java_version: [ 8, 11, 17, 21 ]
+        include:
+          - java_version: '8'
+            included_modules: '-pl !langchain4j-local-ai,!langchain4j-milvus,!code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot,!langchain4j-cassandra,!langchain4j-infinispan,!langchain4j-neo4j,!langchain4j-opensearch,!langchain4j-azure-ai-search'
+          - java_version: '11'
+            included_modules: '-pl !langchain4j-local-ai,!langchain4j-milvus,!code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot,!langchain4j-infinispan,!langchain4j-neo4j'
+          - java_version: '17'
+            included_modules: '-pl !langchain4j-local-ai,!langchain4j-milvus,!code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot'
+          - java_version: '21'
+            included_modules: '-pl !langchain4j-local-ai,!langchain4j-milvus'
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK ${{ matrix.java_version }}
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: ${{ matrix.java_version }}
           distribution: 'temurin'
-          cache: maven
-          server-id: ossrh
-          server-username: OSSRH_USERNAME
-          server-password: OSSRH_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
+          cache: 'maven'
 
       - name: Authenticate to Google Cloud
+        # Needed for langchain4j-vertex-ai and langchain4j-vertex-ai-gemini modules
         uses: 'google-github-actions/auth@v2'
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
 
       - name: Setup Testcontainers Cloud Client
+        # Needed for langchain4j-ollama and other modules using testcontainers
         uses: atomicjar/testcontainers-cloud-setup-action@v1
         with:
           token: ${{ secrets.TC_CLOUD_TOKEN }}
 
-      - name: release
-        run: mvn -B -U --fail-at-end -DskipTests -DskipITs -DskipAnthropicITs -DskipLocalAiITs -DskipMilvusITs -DskipMongoDbAtlasITs -DskipOllamaITs -DskipVearchITs -DskipVertexAiGeminiITs -pl !langchain4j-core,!langchain4j-parent -Psign clean deploy
+      - name: Build with JDK ${{ matrix.java_version }}
+        run: mvn -B -U --fail-at-end ${{ matrix.included_modules }} verify
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -66,6 +75,3 @@ jobs:
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
           WEAVIATE_API_KEY: ${{ secrets.WEAVIATE_API_KEY }}
           WEAVIATE_HOST: ${{ secrets.WEAVIATE_HOST }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelIT.java
@@ -3,11 +3,9 @@ package dev.langchain4j.model.anthropic;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.*;
-import dev.langchain4j.model.anthropic.internal.client.AnthropicHttpException;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -63,11 +61,6 @@ class AnthropicChatModelIT {
             // TODO simplify defining nested properties
             .addParameter("location", OBJECT, property("properties", singletonMap("city", singletonMap("type", "string"))))
             .build();
-
-    @AfterEach
-    void afterEach() throws InterruptedException {
-        Thread.sleep(10_000L); // to avoid hitting rate limits
-    }
 
     @Test
     void should_generate_answer_and_return_token_usage_and_finish_reason_stop() {
@@ -290,26 +283,6 @@ class AnthropicChatModelIT {
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Anthropic API key must be defined. " +
                         "It can be generated here: https://console.anthropic.com/settings/keys");
-    }
-
-    @Test
-    void should_fail_with_rate_limit_error() {
-
-        ChatLanguageModel model = AnthropicChatModel.builder()
-                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
-                .maxTokens(1)
-                .logRequests(true)
-                .logResponses(true)
-                .build();
-
-        assertThatThrownBy(() -> {
-            for (int i = 0; i < 100; i++) {
-                model.generate("Hi");
-            }
-        })
-                .isExactlyInstanceOf(RuntimeException.class) // TODO return AnthropicHttpException (not wrapped)?
-                .hasRootCauseExactlyInstanceOf(AnthropicHttpException.class)
-                .hasMessageContaining("rate_limit_error");
     }
 
     @ParameterizedTest

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatModelIT.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatModelIT.java
@@ -1,10 +1,5 @@
 package dev.langchain4j.model.bedrock;
 
-import static dev.langchain4j.internal.Utils.readBytes;
-import static dev.langchain4j.model.bedrock.BedrockMistralAiChatModel.Types.Mistral7bInstructV0_2;
-import static dev.langchain4j.model.bedrock.BedrockMistralAiChatModel.Types.MistralMixtral8x7bInstructV0_1;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ImageContent;
@@ -12,119 +7,121 @@ import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import software.amazon.awssdk.regions.Region;
+
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.regions.Region;
 
-public class BedrockChatModelIT {
-    
+import static dev.langchain4j.internal.Utils.readBytes;
+import static dev.langchain4j.model.bedrock.BedrockMistralAiChatModel.Types.Mistral7bInstructV0_2;
+import static dev.langchain4j.model.bedrock.BedrockMistralAiChatModel.Types.MistralMixtral8x7bInstructV0_1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".+")
+class BedrockChatModelIT {
+
     private static final String CAT_IMAGE_URL = "https://upload.wikimedia.org/wikipedia/commons/e/e9/Felis_silvestris_silvestris_small_gradual_decrease_of_quality.png";
-    
+
     @Test
-    @Disabled("To run this test, you must have provide your own access key, secret, region")
     void testBedrockAnthropicV3SonnetChatModel() {
-        
+
         BedrockAnthropicMessageChatModel bedrockChatModel = BedrockAnthropicMessageChatModel
-            .builder()
-            .temperature(0.50f)
-            .maxTokens(300)
-            .region(Region.US_EAST_1)
-            .model(BedrockAnthropicMessageChatModel.Types.AnthropicClaude3SonnetV1.getValue())
-            .maxRetries(1)
-            .build();
-        
+                .builder()
+                .temperature(0.50f)
+                .maxTokens(300)
+                .region(Region.US_EAST_1)
+                .model(BedrockAnthropicMessageChatModel.Types.AnthropicClaude3SonnetV1.getValue())
+                .maxRetries(1)
+                .build();
+
         assertThat(bedrockChatModel).isNotNull();
-        
+
         Response<AiMessage> response = bedrockChatModel.generate(UserMessage.from("hi, how are you doing?"));
-        
+
         assertThat(response).isNotNull();
         assertThat(response.content().text()).isNotBlank();
         assertThat(response.tokenUsage()).isNotNull();
         assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
     }
-    
+
     @Test
-    @Disabled("To run this test, you must have provide your own access key, secret, region")
     void testBedrockAnthropicV3SonnetChatModelImageContent() {
-        
+
         BedrockAnthropicMessageChatModel bedrockChatModel = BedrockAnthropicMessageChatModel
-            .builder()
-            .temperature(0.50f)
-            .maxTokens(300)
-            .region(Region.US_EAST_1)
-            .model(BedrockAnthropicMessageChatModel.Types.AnthropicClaude3SonnetV1.getValue())
-            .maxRetries(1)
-            .build();
-        
+                .builder()
+                .temperature(0.50f)
+                .maxTokens(300)
+                .region(Region.US_EAST_1)
+                .model(BedrockAnthropicMessageChatModel.Types.AnthropicClaude3SonnetV1.getValue())
+                .maxRetries(1)
+                .build();
+
         assertThat(bedrockChatModel).isNotNull();
-        
+
         String base64Data = Base64.getEncoder().encodeToString(readBytes(CAT_IMAGE_URL));
         ImageContent imageContent = ImageContent.from(base64Data, "image/png");
         UserMessage userMessage = UserMessage.from(imageContent);
-        
+
         Response<AiMessage> response = bedrockChatModel.generate(userMessage);
-        
+
         assertThat(response).isNotNull();
         assertThat(response.content().text()).isNotBlank();
         assertThat(response.tokenUsage()).isNotNull();
         assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
     }
-    
+
     @Test
-    @Disabled("To run this test, you must have provide your own access key, secret, region")
     void testBedrockAnthropicV3HaikuChatModel() {
-        
+
         BedrockAnthropicMessageChatModel bedrockChatModel = BedrockAnthropicMessageChatModel
-            .builder()
-            .temperature(0.50f)
-            .maxTokens(300)
-            .region(Region.US_EAST_1)
-            .model(BedrockAnthropicMessageChatModel.Types.AnthropicClaude3HaikuV1.getValue())
-            .maxRetries(1)
-            .build();
-        
+                .builder()
+                .temperature(0.50f)
+                .maxTokens(300)
+                .region(Region.US_EAST_1)
+                .model(BedrockAnthropicMessageChatModel.Types.AnthropicClaude3HaikuV1.getValue())
+                .maxRetries(1)
+                .build();
+
         assertThat(bedrockChatModel).isNotNull();
-        
+
         Response<AiMessage> response = bedrockChatModel.generate(UserMessage.from("hi, how are you doing?"));
-        
+
         assertThat(response).isNotNull();
         assertThat(response.content().text()).isNotBlank();
         assertThat(response.tokenUsage()).isNotNull();
         assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
     }
-    
+
     @Test
-    @Disabled("To run this test, you must have provide your own access key, secret, region")
     void testBedrockAnthropicV3HaikuChatModelImageContent() {
-        
+
         BedrockAnthropicMessageChatModel bedrockChatModel = BedrockAnthropicMessageChatModel
-            .builder()
-            .temperature(0.50f)
-            .maxTokens(300)
-            .region(Region.US_EAST_1)
-            .model(BedrockAnthropicMessageChatModel.Types.AnthropicClaude3HaikuV1.getValue())
-            .maxRetries(1)
-            .build();
-        
+                .builder()
+                .temperature(0.50f)
+                .maxTokens(300)
+                .region(Region.US_EAST_1)
+                .model(BedrockAnthropicMessageChatModel.Types.AnthropicClaude3HaikuV1.getValue())
+                .maxRetries(1)
+                .build();
+
         assertThat(bedrockChatModel).isNotNull();
-        
+
         String base64Data = Base64.getEncoder().encodeToString(readBytes(CAT_IMAGE_URL));
         ImageContent imageContent = ImageContent.from(base64Data, "image/png");
         UserMessage userMessage = UserMessage.from(imageContent);
-        
+
         Response<AiMessage> response = bedrockChatModel.generate(userMessage);
-        
+
         assertThat(response).isNotNull();
         assertThat(response.content().text()).isNotBlank();
         assertThat(response.tokenUsage()).isNotNull();
         assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
     }
-    
+
     @Test
-    @Disabled("To run this test, you must have provide your own access key, secret, region")
     void testBedrockAnthropicV2ChatModelEnumModelType() {
 
         BedrockAnthropicCompletionChatModel bedrockChatModel = BedrockAnthropicCompletionChatModel
@@ -145,24 +142,23 @@ public class BedrockChatModelIT {
         assertThat(response.tokenUsage()).isNull();
         assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
     }
-    
+
     @Test
-    @Disabled("To run this test, you must have provide your own access key, secret, region")
     void testBedrockAnthropicV2ChatModelStringModelType() {
-        
+
         BedrockAnthropicCompletionChatModel bedrockChatModel = BedrockAnthropicCompletionChatModel
-            .builder()
-            .temperature(0.50f)
-            .maxTokens(300)
-            .region(Region.US_EAST_1)
-            .model("anthropic.claude-v2")
-            .maxRetries(1)
-            .build();
-        
+                .builder()
+                .temperature(0.50f)
+                .maxTokens(300)
+                .region(Region.US_EAST_1)
+                .model("anthropic.claude-v2")
+                .maxRetries(1)
+                .build();
+
         assertThat(bedrockChatModel).isNotNull();
-        
+
         Response<AiMessage> response = bedrockChatModel.generate(UserMessage.from("hi, how are you doing?"));
-        
+
         assertThat(response).isNotNull();
         assertThat(response.content().text()).isNotBlank();
         assertThat(response.tokenUsage()).isNull();
@@ -170,7 +166,6 @@ public class BedrockChatModelIT {
     }
 
     @Test
-    @Disabled("To run this test, you must have provide your own access key, secret, region")
     void testBedrockTitanChatModel() {
 
         BedrockTitanChatModel bedrockChatModel = BedrockTitanChatModel
@@ -198,7 +193,6 @@ public class BedrockChatModelIT {
     }
 
     @Test
-    @Disabled("To run this test, you must have provide your own access key, secret, region")
     void testBedrockCohereChatModel() {
 
         BedrockCohereChatModel bedrockChatModel = BedrockCohereChatModel
@@ -220,7 +214,6 @@ public class BedrockChatModelIT {
     }
 
     @Test
-    @Disabled("To run this test, you must have provide your own access key, secret, region")
     void testBedrockStabilityChatModel() {
 
         BedrockStabilityAIChatModel bedrockChatModel = BedrockStabilityAIChatModel
@@ -241,97 +234,93 @@ public class BedrockChatModelIT {
         assertThat(response.tokenUsage()).isNull();
         assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
     }
-    
+
     @Test
-    @Disabled("To run this test, you must have provide your own access key, secret, region")
     void testBedrockLlama13BChatModel() {
-        
+
         BedrockLlamaChatModel bedrockChatModel = BedrockLlamaChatModel
-            .builder()
-            .temperature(0.50f)
-            .maxTokens(300)
-            .region(Region.US_EAST_1)
-            .model(BedrockLlamaChatModel.Types.MetaLlama2Chat13B.getValue())
-            .maxRetries(1)
-            .build();
-        
+                .builder()
+                .temperature(0.50f)
+                .maxTokens(300)
+                .region(Region.US_EAST_1)
+                .model(BedrockLlamaChatModel.Types.MetaLlama2Chat13B.getValue())
+                .maxRetries(1)
+                .build();
+
         assertThat(bedrockChatModel).isNotNull();
-        
+
         Response<AiMessage> response = bedrockChatModel.generate(UserMessage.from("hi, how are you doing?"));
-        
+
         assertThat(response).isNotNull();
         assertThat(response.content().text()).isNotBlank();
         assertThat(response.tokenUsage()).isNotNull();
         assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
     }
-    
+
     @Test
-    @Disabled("To run this test, you must have provide your own access key, secret, region")
     void testBedrockLlama70BChatModel() {
-        
+
         BedrockLlamaChatModel bedrockChatModel = BedrockLlamaChatModel
-            .builder()
-            .temperature(0.50f)
-            .maxTokens(300)
-            .region(Region.US_EAST_1)
-            .model(BedrockLlamaChatModel.Types.MetaLlama2Chat70B.getValue())
-            .maxRetries(1)
-            .build();
-        
+                .builder()
+                .temperature(0.50f)
+                .maxTokens(300)
+                .region(Region.US_EAST_1)
+                .model(BedrockLlamaChatModel.Types.MetaLlama2Chat70B.getValue())
+                .maxRetries(1)
+                .build();
+
         assertThat(bedrockChatModel).isNotNull();
-        
+
         Response<AiMessage> response = bedrockChatModel.generate(UserMessage.from("hi, how are you doing?"));
-        
+
         assertThat(response).isNotNull();
         assertThat(response.content().text()).isNotBlank();
         assertThat(response.tokenUsage()).isNotNull();
         assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
     }
-    
+
     @Test
-    @Disabled("To run this test, you must have provide your own access key, secret, region")
     void testBedrockMistralAi7bInstructChatModel() {
-        
+
         BedrockMistralAiChatModel bedrockChatModel = BedrockMistralAiChatModel
-            .builder()
-            .temperature(0.50f)
-            .maxTokens(300)
-            .region(Region.US_EAST_1)
-            .model(Mistral7bInstructV0_2.getValue())
-            .maxRetries(1)
-            .build();
-        
+                .builder()
+                .temperature(0.50f)
+                .maxTokens(300)
+                .region(Region.US_EAST_1)
+                .model(Mistral7bInstructV0_2.getValue())
+                .maxRetries(1)
+                .build();
+
         assertThat(bedrockChatModel).isNotNull();
-        
+
         List<ChatMessage> messages = Arrays.asList(
-            UserMessage.from("hi, how are you doing"),
-            AiMessage.from("I am an AI model so I don't have feelings"),
-            UserMessage.from("Ok no worries, tell me story about a man who wears a tin hat."));
-        
+                UserMessage.from("hi, how are you doing"),
+                AiMessage.from("I am an AI model so I don't have feelings"),
+                UserMessage.from("Ok no worries, tell me story about a man who wears a tin hat."));
+
         Response<AiMessage> response = bedrockChatModel.generate(messages);
-        
+
         assertThat(response).isNotNull();
         assertThat(response.content().text()).isNotBlank();
         assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
     }
-    
+
     @Test
-    @Disabled("To run this test, you must have provide your own access key, secret, region")
     void testBedrockMistralAiMixtral8x7bInstructChatModel() {
-        
+
         BedrockMistralAiChatModel bedrockChatModel = BedrockMistralAiChatModel
-            .builder()
-            .temperature(0.50f)
-            .maxTokens(300)
-            .region(Region.US_EAST_1)
-            .model(MistralMixtral8x7bInstructV0_1.getValue())
-            .maxRetries(1)
-            .build();
-        
+                .builder()
+                .temperature(0.50f)
+                .maxTokens(300)
+                .region(Region.US_EAST_1)
+                .model(MistralMixtral8x7bInstructV0_1.getValue())
+                .maxRetries(1)
+                .build();
+
         assertThat(bedrockChatModel).isNotNull();
-        
+
         Response<AiMessage> response = bedrockChatModel.generate(UserMessage.from("hi, how are you doing?"));
-        
+
         assertThat(response).isNotNull();
         assertThat(response.content().text()).isNotBlank();
         assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockEmbeddingIT.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockEmbeddingIT.java
@@ -4,8 +4,8 @@ import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import software.amazon.awssdk.regions.Region;
 
 import java.util.Collections;
@@ -13,10 +13,10 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BedrockEmbeddingIT {
+@EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".+")
+class BedrockEmbeddingIT {
 
     @Test
-    @Disabled("To run this test, you must have provide your own access key, secret, region")
     void testBedrockTitanChatModel() {
 
         BedrockTitanEmbeddingModel embeddingModel = BedrockTitanEmbeddingModel
@@ -46,5 +46,4 @@ public class BedrockEmbeddingIT {
 
         assertThat(response.finishReason()).isNull();
     }
-
 }

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModelIT.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModelIT.java
@@ -4,17 +4,18 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.TestStreamingResponseHandler;
 import dev.langchain4j.model.output.Response;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import software.amazon.awssdk.regions.Region;
 
 import static dev.langchain4j.data.message.UserMessage.userMessage;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BedrockStreamingChatModelIT {
+@EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".+")
+class BedrockStreamingChatModelIT {
+
     @Test
-    @Disabled("To run this test, you must have provide your own access key, secret, region")
     void testBedrockAnthropicStreamingChatModel() {
         //given
         BedrockAnthropicStreamingChatModel bedrockChatModel = BedrockAnthropicStreamingChatModel
@@ -34,6 +35,4 @@ public class BedrockStreamingChatModelIT {
         //then
         assertThat(response.content().text()).contains("Warsaw");
     }
-
-
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreWithRemovalIT.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreWithRemovalIT.java
@@ -1,0 +1,119 @@
+package dev.langchain4j.store.embedding;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.filter.Filter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
+    @BeforeEach
+    void beforeEach() {
+        embeddingStore().removeAll();
+    }
+
+    @Test
+    void remove_by_id() {
+        Embedding embedding = embeddingModel().embed("hello").content();
+        Embedding embedding2 = embeddingModel().embed("hello2").content();
+        Embedding embedding3 = embeddingModel().embed("hello3").content();
+
+        String id = embeddingStore().add(embedding);
+        String id2 = embeddingStore().add(embedding2);
+        String id3 = embeddingStore().add(embedding3);
+
+        assertThat(id).isNotBlank();
+        assertThat(id2).isNotBlank();
+        assertThat(id3).isNotBlank();
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        assertThat(relevant).hasSize(3);
+
+        embeddingStore().remove(id);
+
+        relevant = embeddingStore().findRelevant(embedding, 10);
+        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
+        assertThat(relevantIds).hasSize(2);
+        assertThat(relevantIds).containsExactly(id2, id3);
+    }
+
+    @Test
+    void remove_all_by_ids() {
+        Embedding embedding = embeddingModel().embed("hello").content();
+        Embedding embedding2 = embeddingModel().embed("hello2").content();
+        Embedding embedding3 = embeddingModel().embed("hello3").content();
+
+        String id = embeddingStore().add(embedding);
+        String id2 = embeddingStore().add(embedding2);
+        String id3 = embeddingStore().add(embedding3);
+
+        embeddingStore().removeAll(Arrays.asList(id2, id3));
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
+        assertThat(relevant).hasSize(1);
+        assertThat(relevantIds).containsExactly(id);
+    }
+
+    @Test
+    void remove_all_by_ids_null() {
+        assertThatThrownBy(() -> embeddingStore().removeAll((Collection<String>) null))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ids cannot be null or empty");
+    }
+
+    @Test
+    void remove_all_by_filter() {
+        Metadata metadata = Metadata.metadata("id", "1");
+        TextSegment segment = TextSegment.from("matching", metadata);
+        Embedding embedding = embeddingModel().embed(segment).content();
+        embeddingStore().add(embedding, segment);
+
+        Embedding embedding2 = embeddingModel().embed("hello2").content();
+        Embedding embedding3 = embeddingModel().embed("hello3").content();
+
+        String id2 = embeddingStore().add(embedding2, new TextSegment("hello2", new Metadata()));
+        String id3 = embeddingStore().add(embedding3, new TextSegment("hello3", new Metadata()));
+
+        embeddingStore().removeAll(metadataKey("id").isEqualTo("1"));
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
+        assertThat(relevantIds).hasSize(2);
+        assertThat(relevantIds).containsExactly(id2, id3);
+    }
+
+    @Test
+    void remove_all_by_filter_not_matching() {
+        Embedding embedding = embeddingModel().embed("hello").content();
+        Embedding embedding2 = embeddingModel().embed("hello2").content();
+        Embedding embedding3 = embeddingModel().embed("hello3").content();
+
+        embeddingStore().add(embedding, new TextSegment("hello", new Metadata()));
+        embeddingStore().add(embedding2, new TextSegment("hello2", new Metadata()));
+        embeddingStore().add(embedding3, new TextSegment("hello3", new Metadata()));
+
+        embeddingStore().removeAll(metadataKey("unknown").isEqualTo("1"));
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
+        assertThat(relevantIds).hasSize(3);
+    }
+
+    @Test
+    void remove_all_by_filter_null() {
+        assertThatThrownBy(() -> embeddingStore().removeAll((Filter) null))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("filter cannot be null");
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreWithRemovalIT.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreWithRemovalIT.java
@@ -36,12 +36,12 @@ public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
         assertThat(id2).isNotBlank();
         assertThat(id3).isNotBlank();
 
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        List<EmbeddingMatch<TextSegment>> relevant = findRelevant(embedding);
         assertThat(relevant).hasSize(3);
 
         embeddingStore().remove(id);
 
-        relevant = embeddingStore().findRelevant(embedding, 10);
+        relevant = findRelevant(embedding);
         List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
         assertThat(relevantIds).hasSize(2);
         assertThat(relevantIds).containsExactly(id2, id3);
@@ -59,7 +59,7 @@ public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
 
         embeddingStore().removeAll(Arrays.asList(id2, id3));
 
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        List<EmbeddingMatch<TextSegment>> relevant = findRelevant(embedding);
         List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
         assertThat(relevant).hasSize(1);
         assertThat(relevantIds).containsExactly(id);
@@ -87,7 +87,7 @@ public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
 
         embeddingStore().removeAll(metadataKey("id").isEqualTo("1"));
 
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        List<EmbeddingMatch<TextSegment>> relevant = findRelevant(embedding);
         List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
         assertThat(relevantIds).hasSize(2);
         assertThat(relevantIds).containsExactly(id2, id3);
@@ -105,7 +105,7 @@ public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
 
         embeddingStore().removeAll(metadataKey("unknown").isEqualTo("1"));
 
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        List<EmbeddingMatch<TextSegment>> relevant = findRelevant(embedding);
         List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
         assertThat(relevantIds).hasSize(3);
     }
@@ -115,5 +115,15 @@ public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
         assertThatThrownBy(() -> embeddingStore().removeAll((Filter) null))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessage("filter cannot be null");
+    }
+
+    List<EmbeddingMatch<TextSegment>> findRelevant(Embedding embedding) {
+        EmbeddingSearchRequest embeddingSearchRequest = EmbeddingSearchRequest
+                .builder()
+                .queryEmbedding(embedding)
+                .maxResults(10)
+                .build();
+
+        return embeddingStore().search(embeddingSearchRequest).matches();
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreWithRemovalIT.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreWithRemovalIT.java
@@ -82,8 +82,8 @@ public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
         Embedding embedding2 = embeddingModel().embed("hello2").content();
         Embedding embedding3 = embeddingModel().embed("hello3").content();
 
-        String id2 = embeddingStore().add(embedding2, new TextSegment("hello2", new Metadata()));
-        String id3 = embeddingStore().add(embedding3, new TextSegment("hello3", new Metadata()));
+        String id2 = embeddingStore().add(embedding2);
+        String id3 = embeddingStore().add(embedding3);
 
         embeddingStore().removeAll(metadataKey("id").isEqualTo("1"));
 
@@ -99,9 +99,9 @@ public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
         Embedding embedding2 = embeddingModel().embed("hello2").content();
         Embedding embedding3 = embeddingModel().embed("hello3").content();
 
-        embeddingStore().add(embedding, new TextSegment("hello", new Metadata()));
-        embeddingStore().add(embedding2, new TextSegment("hello2", new Metadata()));
-        embeddingStore().add(embedding3, new TextSegment("hello3", new Metadata()));
+        embeddingStore().add(embedding);
+        embeddingStore().add(embedding2);
+        embeddingStore().add(embedding3);
 
         embeddingStore().removeAll(metadataKey("unknown").isEqualTo("1"));
 

--- a/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreRemoveIT.java
+++ b/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreRemoveIT.java
@@ -7,6 +7,7 @@ import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreWithRemovalIT;
 import dev.langchain4j.store.embedding.filter.Filter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Testcontainers
-public class PgVectorEmbeddingStoreRemoveIT {
+public class PgVectorEmbeddingStoreRemoveIT extends EmbeddingStoreWithRemovalIT {
 
     @Container
     static PostgreSQLContainer<?> pgVector = new PostgreSQLContainer<>("pgvector/pgvector:pg15");
@@ -41,103 +42,13 @@ public class PgVectorEmbeddingStoreRemoveIT {
 
     EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
 
-    @BeforeEach
-    void beforeEach() {
-        embeddingStore.removeAll();
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
     }
 
-    @Test
-    void remove_by_id() {
-        Embedding embedding = embeddingModel.embed("hello").content();
-        Embedding embedding2 = embeddingModel.embed("hello2").content();
-        Embedding embedding3 = embeddingModel.embed("hello3").content();
-
-        String id = embeddingStore.add(embedding);
-        String id2 = embeddingStore.add(embedding2);
-        String id3 = embeddingStore.add(embedding3);
-
-        assertThat(id).isNotBlank();
-        assertThat(id2).isNotBlank();
-        assertThat(id3).isNotBlank();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(3);
-
-        embeddingStore.remove(id);
-
-        relevant = embeddingStore.findRelevant(embedding, 10);
-        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
-        assertThat(relevantIds).hasSize(2);
-        assertThat(relevantIds).containsExactly(id2, id3);
-    }
-
-    @Test
-    void remove_all_by_ids() {
-        Embedding embedding = embeddingModel.embed("hello").content();
-        Embedding embedding2 = embeddingModel.embed("hello2").content();
-        Embedding embedding3 = embeddingModel.embed("hello3").content();
-
-        String id = embeddingStore.add(embedding);
-        String id2 = embeddingStore.add(embedding2);
-        String id3 = embeddingStore.add(embedding3);
-
-        embeddingStore.removeAll(Arrays.asList(id2, id3));
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
-        assertThat(relevant).hasSize(1);
-        assertThat(relevantIds).containsExactly(id);
-    }
-
-    @Test
-    void remove_all_by_ids_null() {
-        assertThatThrownBy(() -> embeddingStore.removeAll((Collection<String>) null))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("ids cannot be null or empty");
-    }
-
-    @Test
-    void remove_all_by_filter() {
-        Metadata metadata = Metadata.metadata("id", "1");
-        TextSegment segment = TextSegment.from("matching", metadata);
-        Embedding embedding = embeddingModel.embed(segment).content();
-        embeddingStore.add(embedding, segment);
-
-        Embedding embedding2 = embeddingModel.embed("hello2").content();
-        Embedding embedding3 = embeddingModel.embed("hello3").content();
-
-        String id2 = embeddingStore.add(embedding2);
-        String id3 = embeddingStore.add(embedding3);
-
-        embeddingStore.removeAll(metadataKey("id").isEqualTo("1"));
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
-        assertThat(relevantIds).hasSize(2);
-        assertThat(relevantIds).containsExactly(id2, id3);
-    }
-
-    @Test
-    void remove_all_by_filter_not_matching() {
-        Embedding embedding = embeddingModel.embed("hello").content();
-        Embedding embedding2 = embeddingModel.embed("hello2").content();
-        Embedding embedding3 = embeddingModel.embed("hello3").content();
-
-        embeddingStore.add(embedding);
-        embeddingStore.add(embedding2);
-        embeddingStore.add(embedding3);
-
-        embeddingStore.removeAll(metadataKey("unknown").isEqualTo("1"));
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
-        assertThat(relevantIds).hasSize(3);
-    }
-
-    @Test
-    void remove_all_by_filter_null() {
-        assertThatThrownBy(() -> embeddingStore.removeAll((Filter) null))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("filter cannot be null");
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
     }
 }

--- a/langchain4j-qianfan/src/main/java/dev/langchain4j/model/qianfan/client/chat/ChatCompletionRequest.java
+++ b/langchain4j-qianfan/src/main/java/dev/langchain4j/model/qianfan/client/chat/ChatCompletionRequest.java
@@ -16,6 +16,8 @@ public final class ChatCompletionRequest {
     private final String userId;
     private final List<Function> functions;
     private final String system;
+    private final List<String> stop;
+    private final Integer maxOutputTokens;
 
     private final String responseFormat;
 
@@ -29,6 +31,8 @@ public final class ChatCompletionRequest {
         this.functions = builder.functions;
         this.system = builder.system;
         this.responseFormat = builder.responseFormat;
+        this.stop = builder.stop;
+        this.maxOutputTokens=builder.maxOutputTokens;
     }
 
 
@@ -67,9 +71,6 @@ public final class ChatCompletionRequest {
     }
 
 
-
-
-
     @Override
     public String toString() {
         return "ChatCompletionRequest{" +
@@ -81,6 +82,9 @@ public final class ChatCompletionRequest {
                 ", userId='" + userId + '\'' +
                 ", functions=" + functions +
                 ", system='" + system + '\'' +
+                ", stop=" + stop +
+                ", maxOutputTokens=" + maxOutputTokens +
+                ", responseFormat='" + responseFormat + '\'' +
                 '}';
     }
 
@@ -100,7 +104,8 @@ public final class ChatCompletionRequest {
         private  String system;
 
         private  String responseFormat;
-
+        private  List<String> stop;
+        private  Integer maxOutputTokens;
         private Builder() {
         }
 
@@ -167,12 +172,21 @@ public final class ChatCompletionRequest {
             return this;
         }
 
+
         public Builder temperature(Double temperature) {
             this.temperature = temperature;
             return this;
         }
         public Builder system(String system) {
             this.system = system;
+            return this;
+        }
+        public Builder maxOutputTokens(Integer maxOutputTokens) {
+            this.maxOutputTokens = maxOutputTokens;
+            return this;
+        }
+        public Builder stop(List<String> stop) {
+            this.stop = stop;
             return this;
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/SegmentBuilder.java
+++ b/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/SegmentBuilder.java
@@ -26,7 +26,7 @@ class SegmentBuilder {
         this.maxSegmentSize = ensureGreaterThanZero(maxSegmentSize, "maxSegmentSize");
         this.sizeFunction = ensureNotNull(sizeFunction, "sizeFunction");
         this.joinSeparator = ensureNotNull(joinSeparator, "joinSeparator");
-        joinSeparatorSize = sizeOf(joinSeparator);
+        this.joinSeparatorSize = sizeOf(joinSeparator);
     }
 
     /**

--- a/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
+++ b/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
@@ -17,6 +17,7 @@ import java.util.stream.IntStream;
 
 import static dev.langchain4j.internal.Utils.randomUUID;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 import static java.nio.file.StandardOpenOption.CREATE;
@@ -102,11 +103,15 @@ public class InMemoryEmbeddingStore<Embedded> implements EmbeddingStore<Embedded
 
     @Override
     public void removeAll(Collection<String> ids) {
+        ensureNotEmpty(ids, "ids");
+
         entries.removeIf(entry -> ids.contains(entry.id));
     }
 
     @Override
     public void removeAll(Filter filter) {
+        ensureNotNull(filter, "filter");
+
         entries.removeIf(entry -> {
             if (entry.embedded instanceof TextSegment) {
                 return filter.test(((TextSegment) entry.embedded).metadata());

--- a/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
+++ b/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
@@ -115,6 +115,8 @@ public class InMemoryEmbeddingStore<Embedded> implements EmbeddingStore<Embedded
         entries.removeIf(entry -> {
             if (entry.embedded instanceof TextSegment) {
                 return filter.test(((TextSegment) entry.embedded).metadata());
+            } else if (entry.embedded == null) {
+                return false;
             } else {
                 throw new UnsupportedOperationException("Not supported yet.");
             }

--- a/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
+++ b/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
@@ -96,6 +96,32 @@ public class InMemoryEmbeddingStore<Embedded> implements EmbeddingStore<Embedded
     }
 
     @Override
+    public void remove(String id) {
+        entries.removeIf(entry -> entry.id.equals(id));
+    }
+
+    @Override
+    public void removeAll(Collection<String> ids) {
+        entries.removeIf(entry -> ids.contains(entry.id));
+    }
+
+    @Override
+    public void removeAll(Filter filter) {
+        entries.removeIf(entry -> {
+            if (entry.embedded instanceof TextSegment) {
+                return filter.test(((TextSegment) entry.embedded).metadata());
+            } else {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
+        });
+    }
+
+    @Override
+    public void removeAll() {
+        entries.clear();
+    }
+
+    @Override
     public EmbeddingSearchResult<Embedded> search(EmbeddingSearchRequest embeddingSearchRequest) {
 
         Comparator<EmbeddingMatch<Embedded>> comparator = comparingDouble(EmbeddingMatch::score);

--- a/langchain4j/src/test/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStoreRemovalTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStoreRemovalTest.java
@@ -1,0 +1,23 @@
+package dev.langchain4j.store.embedding.inmemory;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreWithRemovalIT;
+
+public class InMemoryEmbeddingStoreRemovalTest extends EmbeddingStoreWithRemovalIT {
+    EmbeddingStore<TextSegment> embeddingStore = new InMemoryEmbeddingStore<>();
+
+    EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
+    }
+
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
+    }
+}


### PR DESCRIPTION

<!-- Thank you so much for your contribution! -->
<!-- Please fill in all the sections below. -->

<!-- Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples. -->
<!-- Please note that PRs with breaking changes will be rejected. -->
<!-- Please note that PRs without tests will be rejected. -->

<!-- Please note that PRs will be reviewed based on the priority of the issues they address. -->
<!-- We ask for your patience. We are doing our best to review your PR as quickly as possible. -->
<!-- Please refrain from pinging and asking when it will be reviewed. Thank you for understanding! -->


## Issue
[https://github.com/langchain4j/langchain4j/issues/301](https://github.com/langchain4j/langchain4j/issues/301)


## Change
I've implemented remove methods for InMemoryEmbeddingStore.

Current problems:
1. I'm not completely sure how to test all of this. And, as I've seen, you don't fully test it too)
2. There is a very nasty problem with `removeAll(Filter filter)` . Let me try to break it in small pieces:
   1. `EmbeddingStore`'s are parametrized with `Embedded` type parameter.
   2. `removeAll(Filter filter)` method in `EmbeddingStore` accepts `Filter`.
   3. `Filter` accepts `Metadata` object.
   4. `Metadata` object is stored in `TextSegment`.
   5. `TextSegment` is usually what is `Embedded`. But it's not guaranteed.

How my pull request deals with this problem: 
1) for every entry in `InMemoryEmbeddingStore` check the type of `Embedded`. 
2) If it's a `TextSegment`, then proceed.
3) If it's not, then raise `UnsupportedOperationException`.
The issue with this strategy is that we perform the check for every entry. I haven't found a way in Java to check the type of type parameter (because it's erasured in runtime). (*In C++, for example, there are `constexpr if`, `<type_traits>`, `std::is_same<U, V>`, explicit specialization, etc.*)

We could solve this problem if `InMemoryEmbeddingStore` would support only `TextSegment` as `Embedded`, but that's a breaking change.

I could also not implement this method, but, I really really need it in my project (if we chose to stick with `InMemoryEmbeddingStore`).
  


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [ ] I have added unit and integration tests for my change
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)


## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
